### PR TITLE
Fix: use sendmail full path

### DIFF
--- a/mailnotify.cpp
+++ b/mailnotify.cpp
@@ -170,7 +170,7 @@ class CNotifoMod : public CModule
 			strftime(iso8601, 20, "%Y-%m-%d %H:%M:%S", timeinfo);
 
 			// forge the mailcmd
-			CString cmd = "echo -e \"Subject:" + options["email_subject"] + "\n" + options["email_header"] + "\n" + message + "\n\" | sendmail " + options["email_address"];
+			CString cmd = "echo -e \"Subject:" + options["email_subject"] + "\n" + options["email_header"] + "\n" + message + "\n\" | /usr/sbin/sendmail " + options["email_address"];
 
 			// create a new exec thread
 			int pid;


### PR DESCRIPTION
sendmail is installed in `/usr/sbin` and $PATH for unprivileged users does not include `/usr/sbin`.
This PR make sure that sendmail is used with the full path.