### PR TITLE
Fix: remove bash dependency

### DIFF
--- a/mailnotify.cpp
+++ b/mailnotify.cpp
@@ -182,7 +182,7 @@ class CNotifoMod : public CModule
 			else if(pid == 0) /* child executes this */
 			{
 				// execute mailcommand
-				execl("/bin/bash", "bash", "-c", cmd.c_str(), NULL);
+				execl("/bin/sh", "sh", "-c", cmd.c_str(), NULL);
 				exit(0);
 			}
 			else /* parent executes this */


### PR DESCRIPTION
If you're running Alpine you will not have `bash` installed by default. As such, it is enough just to call `sh`